### PR TITLE
Tip: PEP8 imports

### DIFF
--- a/consulta.py
+++ b/consulta.py
@@ -1,4 +1,5 @@
 import requests
+
 import pandas as pd
 
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from menu import menu, escolher_opcao, apontar_funcoes
+from menu import apontar_funcoes, escolher_opcao, menu
 
 opcao = ''
 while opcao != '3':

--- a/menu.py
+++ b/menu.py
@@ -1,9 +1,10 @@
-from lista_menu import lista
-from consulta import buscar_por_cep, buscar_por_end
-from save_file import save_file, save_xls
-import sys
 import os
+import sys
 import time
+
+from consulta import buscar_por_cep, buscar_por_end
+from lista_menu import lista
+from save_file import save_file, save_xls
 
 
 def menu():

--- a/save_file.py
+++ b/save_file.py
@@ -1,5 +1,6 @@
-from consulta import buscar_por_cep, buscar_por_end
 import pandas as pd
+
+from consulta import buscar_por_cep, buscar_por_end
 
 
 def save_file():


### PR DESCRIPTION
## Problema
Organização dos imports fora da convenção estabelecida pela PEP8. Isso atrapalha a legibilidade e compreenção das dependências de cada módulo.

## Solução
Seguir as convenções do [PEP8, o guia de estilo de código do Python](https://peps.python.org/pep-0008).
Na [seção sobre imports](https://peps.python.org/pep-0008/#imports), ele indica como devem ser organizados:

> Imports should be grouped in the following order:
>   1. Standard library imports.
>   2. Related third party imports.
>   3. Local application/library specific imports.
>
> You should put a blank line between each group of imports.

#### Mais informações
[Artigo em português explicando um pouco mais sobre PEP8 e imports](https://medium.com/gbtech/pep-8-e-imports-em-python-78a6fbf53475).